### PR TITLE
Missing method for :supplier_id

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -8,4 +8,8 @@ Spree::Product.class_eval do
     supplier_product.present? && supplier.present?
   end
 
+  # Returns id of supplier
+  def supplier_id
+    :id
+  end
 end


### PR DESCRIPTION
Request for /admin/products/.../edit errors out with missing method: :supplier_id

Not sure if this is the right solution but should highlight the problem.
