### PR TITLE
Fixed a small bug in the bank account functionality

### DIFF
--- a/app/controllers/spree/admin/supplier_bank_accounts_controller.rb
+++ b/app/controllers/spree/admin/supplier_bank_accounts_controller.rb
@@ -21,7 +21,7 @@ class Spree::Admin::SupplierBankAccountsController < Spree::Admin::ResourceContr
   end
 
   def new
-    @bank_account = @supplier.bank_accounts.build
+    @object = @supplier.bank_accounts.build
   end
 
   # Overridding the flash[:success]

--- a/app/views/spree/admin/supplier_bank_accounts/new.html.erb
+++ b/app/views/spree/admin/supplier_bank_accounts/new.html.erb
@@ -6,9 +6,9 @@
    <%= I18n.t '.new_bank_account' %>
 <% end %>
 
-<%= render 'spree/shared/error_messages', :target => @bank_account %>
+<%= render 'spree/shared/error_messages', :target => @object %>
 
-<%= form_for @bank_account, url: spree.admin_supplier_bank_accounts_path(@supplier) do |f| %>
+<%= form_for @object, url: spree.admin_supplier_bank_accounts_path(@supplier) do |f| %>
   <%= f.field_container :name do %>
     <%= f.label :name %>:<br />
     <%= f.text_field :name, :class => 'fullwidth' %>


### PR DESCRIPTION
While experimentally removing payment verification from the bank account model, I noticed that the controller had a mixture of variable names for the current bank account model - specifically, there was a template error if the form was saved with invalid data in it.
