### PR TITLE
Fix supplier page titles by changing nesting of translations. Minor typo...

### DIFF
--- a/app/controllers/spree/admin/drop_ship_orders_controller.rb
+++ b/app/controllers/spree/admin/drop_ship_orders_controller.rb
@@ -5,7 +5,7 @@ module Spree
       def confirm
         @order = DropShipOrder.accessible_by(current_ability, :update).find(params[:id])
         if @order.confirm!
-          flash[:notice] = I18n.t('spree.admin.drop_ship_orders.confirm.success', number: @order.id)
+          flash[:notice] = I18n.t('spree.drop_ship_orders.confirm.success', number: @order.id)
         end
         redirect_to spree.edit_admin_drop_ship_order_path(@order)
       end
@@ -13,7 +13,7 @@ module Spree
       def deliver
         @order = DropShipOrder.accessible_by(current_ability, :update).find(params[:id])
         if @order.deliver!
-          flash[:notice] = I18n.t('spree.admin.drop_ship_orders.deliver.success', number: @order.id)
+          flash[:notice] = I18n.t('spree.drop_ship_orders.deliver.success', number: @order.id)
         end
         redirect_to spree.edit_admin_drop_ship_order_path(@order)
       end

--- a/app/views/spree/admin/suppliers/edit.html.erb
+++ b/app/views/spree/admin/suppliers/edit.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <%== I18n.t(:editing_supplier) + " &ldquo;#{@supplier.name}&rdquo;".html_safe %>
+  <%= I18n.t(:editing_supplier) + " #{@supplier.name}".html_safe %>
 <% end %>
 
 <%= render 'spree/shared/error_messages', :target => @supplier %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-   <i class="icon-arrow-right"></i> <%= I18n.t(:listing_suppliers) %>
+  <%= I18n.t(:listing_suppliers) %>
 <% end %>
 
 <% content_for :table_filter_title do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,32 +42,32 @@ en:
   signup_to_become_a_supplier: 'Sign Up To Become A Supplier'
   spree:
     admin:
-      drop_ship_orders:
-        confirm:
-          success: "Drop ship order %{number} was successfully confirmed!"
-        deliver:
-          success: "Drop ship order %{number} was successfully delivered!"
       drop_ship_settings:
         update:
           success: Drop ship settings successfully updated.
-      orders:
-        edit:
-          approve_drop_ship_orders: Approve Drop Ship Orders
-          resend_drop_ship_orders: Resend Drop Ship Orders
-          drop_ship_order_approval_confirmation: This will send an email notification to each supplier. Continue?
-        show:
-          approve_drop_ship_orders: Approve Drop Ship Orders
-          resend_drop_ship_orders: Resend Drop Ship Orders
-          drop_ship_order_approval_confirmation: This will send an email notification to each supplier. Continue?
-      suppliers:
-        form:
-          supplier_details: Supplier Details
-          supplier_address: Supplier Address
-      drop_ship_orders:
-        deliver:
-          success: "Drop ship order %{number} was successfully sent!"
-        orders_sent: All drop ship orders have successfully been sent
-        orders_not_sent: Some or all of the drop ship orders could not be sent. Please contact the suppliers directly.
+    drop_ship_orders:
+      confirm:
+        success: "Drop ship order %{number} was successfully confirmed!"
+      deliver:
+        success: "Drop ship order %{number} was successfully delivered!"
+    orders:
+      edit:
+        approve_drop_ship_orders: Approve Drop Ship Orders
+        resend_drop_ship_orders: Resend Drop Ship Orders
+        drop_ship_order_approval_confirmation: This will send an email notification to each supplier. Continue?
+      show:
+        approve_drop_ship_orders: Approve Drop Ship Orders
+        resend_drop_ship_orders: Resend Drop Ship Orders
+        drop_ship_order_approval_confirmation: This will send an email notification to each supplier. Continue?
+    suppliers:
+      form:
+        supplier_details: Supplier Details
+        supplier_address: Supplier Address
+    drop_ship_orders:
+      deliver:
+        success: "Drop ship order %{number} was successfully sent!"
+      orders_sent: All drop ship orders have successfully been sent
+      orders_not_sent: Some or all of the drop ship orders could not be sent. Please contact the suppliers directly.
     drop_ship_order_mailer:
       supplier_order:
         hello: "Hello %{name},"
@@ -80,7 +80,7 @@ en:
       delivered: Delivered
     shared:
       unauthorized:
-        explained: Your not authorized to access this page.
+        explained: You are not authorized to access this page.
         unauthorized: Unauthorized
     show_only_incomplete_orders: Show Only Incomplete Orders
     supplier_mailer:

--- a/spec/features/admin/drop_ship_orders_spec.rb
+++ b/spec/features/admin/drop_ship_orders_spec.rb
@@ -30,7 +30,7 @@ describe 'Admin - Drop Ship Orders', js: true do
 
       it 'deliver button should properly fire for resend' do
         click_button 'Resend Order To Supplier'
-        page.should have_content(I18n.t('spree.admin.drop_ship_orders.deliver.success', number: @order1.id))
+        page.should have_content(I18n.t('spree.drop_ship_orders.deliver.success', number: @order1.id))
       end
     end
 
@@ -84,7 +84,7 @@ describe 'Admin - Drop Ship Orders', js: true do
 
       it 'should properly display and allow confirmation' do
         click_button 'Confirm Order'
-        page.should have_content(I18n.t('spree.admin.drop_ship_orders.confirm.success', number: @order1.id))
+        page.should have_content(I18n.t('spree.drop_ship_orders.confirm.success', number: @order1.id))
       end
 
       it 'should render unauthorized when trying to access another suppliers orders' do

--- a/spec/features/admin/suppliers_spec.rb
+++ b/spec/features/admin/suppliers_spec.rb
@@ -122,6 +122,7 @@ feature 'Admin - Suppliers', js: true do
       page.should_not have_css('#s2id_supplier_user_ids') # cannot edit assigned users
       page.should_not have_css('#supplier_commission_flat_rate') # cannot edit flat rate commission
       page.should_not have_css('#supplier_commission_percentage') # cannot edit comission percentage
+      page.title.should have_content('Test Supplier')
       click_button 'Update'
       page.should have_content('Supplier "Test Supplier" has been successfully updated!')
       page.current_path.should eql(spree.edit_admin_supplier_path(@user.reload.supplier))


### PR DESCRIPTION
... fix also. Move translations out from under admin because it matches Spree core more now.
