### PR TITLE
Fix admin tab conversion - will still work with removed overview tab.

### DIFF
--- a/app/overrides/spree/admin/shared/_tabs/remove_overview_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_tabs/remove_overview_tab.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- replace "code[erb-loud]:contains('overview')" -->
+
+<% if spree_current_user.admin? %>
+  <%= tab :overview, route: :admin, icon: 'icon-dashboard' %>
+<% end %>

--- a/app/overrides/spree/admin/shared/_tabs/replace_overview_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_tabs/replace_overview_tab.html.erb.deface
@@ -1,7 +1,0 @@
-<!-- replace "code[erb-loud]:contains('overview')" -->
-
-<% if spree_current_user.admin? %>
-  <%= tab :overview, route: :admin, icon: 'icon-dashboard' %>
-<% elsif spree_current_user.supplier? %>
-  <%= tab :profile, url: spree.edit_admin_supplier_url(spree_current_user.supplier_id), match_path: '/suppliers', icon: 'icon-user' %>
-<% end %>

--- a/app/overrides/spree/layouts/admin/add_profile_admin_tabs.html.erb.deface
+++ b/app/overrides/spree/layouts/admin/add_profile_admin_tabs.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_top "[data-hook='admin_tabs']" -->
+
+<% if spree_current_user.supplier? %>
+  <%= tab :profile, url: spree.edit_admin_supplier_url(spree_current_user.supplier_id), match_path: '/suppliers', icon: 'icon-user' %>
+<% end %>


### PR DESCRIPTION
Since overview tab has been removed because of Jirafe issues, this is a solution that will work if the overview tab exists or not.
