### PR TITLE
Suppliers can manage multiple locations.

### DIFF
--- a/app/controllers/spree/admin/stock_locations_controller_decorator.rb
+++ b/app/controllers/spree/admin/stock_locations_controller_decorator.rb
@@ -1,0 +1,12 @@
+Spree::Api::StockLocationsController.class_eval do
+  
+  before_filter :supplier_transfers, only: [:index]
+
+  private
+  
+  def supplier_transfers
+    params[:q] ||= {}
+    params[:q][:supplier_id_eq] = spree_current_user.supplier_id
+  end
+  
+end

--- a/app/controllers/spree/api/stock_locations_controller_decorator.rb
+++ b/app/controllers/spree/api/stock_locations_controller_decorator.rb
@@ -1,0 +1,12 @@
+Spree::Api::StockLocationsController.class_eval do
+  
+  before_filter :supplier_locations, only: [:index]
+
+  private
+  
+  def supplier_locations
+    params[:q] ||= {}
+    params[:q][:supplier_id_eq] = spree_current_user.supplier_id
+  end
+  
+end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -3,6 +3,8 @@ Spree::StockLocation.class_eval do
   belongs_to :supplier
   attr_accessible :supplier_id
 
+  scope :with_supplier, ->(supplier) { where(supplier_id: supplier) }
+
   # Wrapper for creating a new stock item respecting the backorderable config and supplier
   # def propagate_variant(variant)
   #   self.stock_items.create!(variant: variant, backorderable: self.backorderable_default)

--- a/app/models/spree/supplier_ability.rb
+++ b/app/models/spree/supplier_ability.rb
@@ -25,6 +25,7 @@ module Spree
         can [:admin, :manage, :read, :ready, :ship], Spree::Shipment, stock_location: { supplier_id: user.supplier_id }
         can [:admin, :manage], Spree::StockItem, variant: { product: { supplier_id: user.supplier_id } } 
         can [:admin, :manage], Spree::StockLocation, supplier_id: user.supplier_id
+        can :create, Spree::StockLocation
         can [:admin, :manage], Spree::StockMovement, stock_item: { variant: { product: { supplier_id: user.supplier_id } } }
         can [:admin, :update], Spree::Supplier, id: user.supplier_id
         can [:admin, :manage], Spree::Variant, product: { supplier_id: user.supplier_id }

--- a/app/overrides/spree/admin/stock_locations/index/remove_configuration_menu.html.erb.deface
+++ b/app/overrides/spree/admin/stock_locations/index/remove_configuration_menu.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- surround 'code[erb-loud]:contains("render :partial => \'spree/admin/shared/configuration_menu\'")' -->
+<% if !spree_current_user.supplier? %>
+	<%= render_original %>
+<% end %>

--- a/app/overrides/spree/layouts/admin/converted_admin_tabs.html.erb.deface
+++ b/app/overrides/spree/layouts/admin/converted_admin_tabs.html.erb.deface
@@ -1,8 +1,12 @@
 <!-- insert_bottom "[data-hook='admin_tabs']" -->
 
 <% if can? :index, Spree::Supplier %>
-  <%= tab :suppliers, label: Spree.t(:suppliers), match_path: '/suppliers', icon: 'icon-user' %>
+  <%= tab :suppliers, label: Spree.t(:suppliers), match_path: '/suppliers', icon: 'icon-building' %>
 <% end %>
 <% if can? :index, Spree::DropShipOrder %>
-  <%= tab :drop_ship_orders, label: Spree.t(:drop_ship_orders), match_path: '/drop_ship_orders', icon: 'icon-shopping-cart' %>
+  <%= tab :drop_ship_orders, label: Spree.t(:drop_ship_orders), match_path: '/drop_ship_orders', icon: 'icon-truck' %>
 <% end %>
+<% if spree_current_user.supplier? and can? :index, Spree::StockLocation %>
+	<%= tab :stock_locations, label: Spree.t(:stock_locations), match_path: '/stock_locations', icon: 'icon-map-marker' %>
+<% end %>
+

--- a/spec/features/admin/stock_spec.rb
+++ b/spec/features/admin/stock_spec.rb
@@ -25,14 +25,71 @@ feature 'Admin - Product Stock Management', js: true do
 
   context 'as Supplier' do
 
-    scenario 'should only display suppliers stock locations' do
+    before(:each) do
       login_user @user
+      visit '/admin/products'
+      click_link "Stock Locations"
+    end
+
+    scenario 'should only display suppliers stock locations' do
       visit spree.stock_admin_product_path(@product)
 
       within '.stock_location_info' do
         page.should have_content(@supplier1.name)
         page.should_not have_content(@supplier2.name)
       end
+    end
+
+    scenario "can create a new stock location" do
+      visit spree.new_admin_stock_location_path
+      
+      fill_in "Name", with: "London"
+      check "Active"
+      click_button "Create"
+
+      page.should have_content("successfully created")
+      page.should have_content("London")
+    end
+
+    scenario "can delete an existing stock location", js: true do
+      create(:stock_location, supplier: @user.supplier)
+      visit current_path
+      
+      find('#listing_stock_locations').should have_content("NY Warehouse")
+      within_row(2) { click_icon :trash }
+      page.driver.browser.switch_to.alert.accept
+      # Wait for API request to complete.
+      sleep(1)
+      visit current_path
+
+      find('#listing_stock_locations').should_not have_content("NY Warehouse")
+    end
+
+    scenario "can update an existing stock location" do
+      create(:stock_location, supplier: @user.supplier)
+      visit current_path
+      
+      page.should have_content("Big Store")
+
+      within_row(1) { click_icon :edit }
+      fill_in "Name", with: "London"
+      click_button "Update"
+
+      page.should have_content("successfully updated")
+      page.should have_content("London")
+    end
+
+    scenario "can deactivate an existing stock location" do
+      create(:stock_location, supplier: @user.supplier)
+      visit current_path
+      
+      page.should have_content("Big Store")
+
+      within_row(1) { click_icon :edit }
+      uncheck "Active"
+      click_button "Update"
+
+      find('#listing_stock_locations').should have_content("INACTIVE")
     end
 
   end


### PR DESCRIPTION
Spec is failing on supplier adding new location because of a routing issue. Works when running the dummy app, but fails to "visit spree.new_admin_stock_location_path" and gives flash message "Stock location is not found" which seems like it is trying to lookup a stock location rather than go to new action.
