### PR TITLE
remove contacts_date_of_birth attr

### DIFF
--- a/lib/tasks/spree_sample.rake
+++ b/lib/tasks/spree_sample.rake
@@ -43,7 +43,6 @@ namespace :spree_sample do
       supplier = Spree::Supplier.new(:name => name, 
                                    :email => "#{name.parameterize}@example.com",
                                    :url => "http://example.com",
-                                   :contacts_date_of_birth => '1966/01/01',
                                    :merchant_type => 'individual')
       supplier.build_address(:firstname => name, :lastname => name,
                              :address1 => "100 State St",


### PR DESCRIPTION
When running

```
rake spree_sample:suppliers
```

I was getting a "cannot assign mass protected" error on the field :contacts_date_of_birth.

That is because this column was removed in the last migrate:

https://github.com/jdutil/spree_drop_ship/blob/master/db/migrate/20130829004248_remove_date_of_birth.rb#L3

So I removed it from the rake task
