### PR TITLE
Supplier Email Never Sent

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -9,7 +9,7 @@ Spree::Order.class_eval do
     finalize_without_drop_ship!
     create_drop_ship_orders
     if SpreeDropShip::Config[:automatically_deliver_orders_to_supplier]
-      drop_ship_orders.each &:deliver!
+      drop_ship_orders(true).each &:deliver!
     end
   end
   alias_method_chain :finalize!, :drop_ship


### PR DESCRIPTION
Association cache was not reloaded on order_decorator after creating drop ship orders through supplier object in create_drop_ship_orders.

This will be empty in finalize_with_drop_ship! when we try to iterate through drop ship orders to send supplier email.
added flag to force association reload & send email.

Existing Test passed because association cache was empty so expectations were never actually set on drop ship orders.  Refactored tests to capture deliver! call count.
