### PR TITLE
When a Supplier adds a Product, they should be associated

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -3,6 +3,8 @@ Spree::Admin::ProductsController.class_eval do
   before_filter :get_suppliers, only: [:edit, :update]
   before_filter :supplier_collection, only: [:index]
 
+  create.after :add_product_to_supplier
+
   private
 
   def get_suppliers
@@ -13,6 +15,13 @@ Spree::Admin::ProductsController.class_eval do
   def supplier_collection
     if try_spree_current_user && !try_spree_current_user.admin? && try_spree_current_user.supplier?
       @collection = @collection.joins(:suppliers).where('spree_suppliers.id = ?', try_spree_current_user.supplier_id)
+    end
+  end
+
+  # Newly added products by a Supplier are associated with it.
+  def add_product_to_supplier
+    if try_spree_current_user && try_spree_current_user.supplier?
+      @product.add_supplier!(try_spree_current_user.supplier_id)
     end
   end
 


### PR DESCRIPTION
Generates a relation between newly created Spree::Products (or Variants) and the Supplier that created it. This avoids an error while trying to associate a specific product with a supplier.

A more detailed discussion in : https://github.com/spree-contrib/spree_drop_ship/issues/56

