### PR TITLE
Better handling for variants with multiple suppliers

### DIFF
--- a/app/models/spree/stock/splitter/drop_ship.rb
+++ b/app/models/spree/stock/splitter/drop_ship.rb
@@ -12,10 +12,14 @@ module Spree
             # Determine which supplier to package drop shipped items.
             drop_ship = package.contents.select { |content| content.variant.suppliers.count > 0 }
             drop_ship.each do |content|
-              # Select supplier providing at the lowest cost.
-              supplier = content.variant.supplier_variants.order('spree_supplier_variants.cost ASC').first.supplier
-              # Select first available stock location.
-              stock_location = supplier.stock_locations.detect { |sl| sl.stock_items.find_by_variant_id(content.variant.id) }
+              # Select the related variant
+              variant = content.variant
+              # Select suppliers ordering ascending according to cost.
+              suppliers = variant.supplier_variants.order('spree_supplier_variants.cost ASC').map(&:supplier)
+              # Select first supplier that has stock location with avialable stock item.
+              available_supplier = suppliers.detect { |supplier| supplier.stock_locations_with_available_stock_items(variant).any? }
+              # Select the first available stock location with in the available_supplier stock locations.
+              stock_location = available_supplier.stock_locations_with_available_stock_items(variant).first
               # Add to any existing packages or create a new one.
               if existing_package = split_packages.detect { |p| p.stock_location == stock_location }
                 existing_package.contents << content

--- a/app/models/spree/stock/splitter/drop_ship.rb
+++ b/app/models/spree/stock/splitter/drop_ship.rb
@@ -15,7 +15,7 @@ module Spree
               # Select the related variant
               variant = content.variant
               # Select suppliers ordering ascending according to cost.
-              suppliers = variant.supplier_variants.order('spree_supplier_variants.cost ASC').map(&:supplier)
+              suppliers = variant.supplier_variants.order("spree_supplier_variants.cost ASC").map(&:supplier)
               # Select first supplier that has stock location with avialable stock item.
               available_supplier = suppliers.detect { |supplier| supplier.stock_locations_with_available_stock_items(variant).any? }
               # Select the first available stock location with in the available_supplier stock locations.

--- a/app/models/spree/stock/splitter/drop_ship.rb
+++ b/app/models/spree/stock/splitter/drop_ship.rb
@@ -26,7 +26,7 @@ module Spree
               if existing_package = split_packages.detect { |p| p.stock_location == stock_location }
                 existing_package.contents << content
               else
-                split_packages << Spree::Stock::Package.new(stock_location, order, [content])
+                split_packages << Spree::Stock::Package.new(stock_location, [content])
               end
             end
           end

--- a/app/models/spree/stock/splitter/drop_ship.rb
+++ b/app/models/spree/stock/splitter/drop_ship.rb
@@ -17,7 +17,9 @@ module Spree
               # Select suppliers ordering ascending according to cost.
               suppliers = variant.supplier_variants.order("spree_supplier_variants.cost ASC").map(&:supplier)
               # Select first supplier that has stock location with avialable stock item.
-              available_supplier = suppliers.detect { |supplier| supplier.stock_locations_with_available_stock_items(variant).any? }
+              available_supplier = suppliers.detect do |supplier| 
+                supplier.stock_locations_with_available_stock_items(variant).any?
+              end
               # Select the first available stock location with in the available_supplier stock locations.
               stock_location = available_supplier.stock_locations_with_available_stock_items(variant).first
               # Add to any existing packages or create a new one.

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -10,9 +10,9 @@ Spree::StockLocation.class_eval do
       self.stock_items.create!(variant: variant, backorderable: self.backorderable_default)
     end
   end
-  
+
   def available?(variant)
     stock_item(variant).try(:available?)
   end
-  
+
 end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -10,5 +10,9 @@ Spree::StockLocation.class_eval do
       self.stock_items.create!(variant: variant, backorderable: self.backorderable_default)
     end
   end
-
+  
+  def available?(variant)
+    stock_item(variant).try(:available?)
+  end
+  
 end

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -54,7 +54,12 @@ class Spree::Supplier < Spree::Base
   def user_ids_string=(s)
     self.user_ids = s.to_s.split(',').map(&:strip)
   end
-
+  
+  # Retreive the stock locations that has available stock items of the given variant 
+  def stock_locations_with_available_stock_items(variant)
+    stock_locations.select { |sl| sl.available?(variant) }
+  end
+  
   #==========================================
   # Protected Methods
 

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -54,12 +54,13 @@ class Spree::Supplier < Spree::Base
   def user_ids_string=(s)
     self.user_ids = s.to_s.split(',').map(&:strip)
   end
-  
-  # Retreive the stock locations that has available stock items of the given variant 
+
+  # Retreive the stock locations that has available
+  # stock items of the given variant 
   def stock_locations_with_available_stock_items(variant)
     stock_locations.select { |sl| sl.available?(variant) }
   end
-  
+
   #==========================================
   # Protected Methods
 

--- a/spec/features/admin/shipments_spec.rb
+++ b/spec/features/admin/shipments_spec.rb
@@ -28,7 +28,10 @@ describe 'Admin - Shipments', js: true do
       # TODO this is a hack until capture_on_dispatch finished https://github.com/spree/spree/issues/4727
       shipment.update_attribute :state, 'ready'
 
-      login_user create(:user, supplier: supplier)
+      user = create(:user, supplier: supplier)
+      user.generate_spree_api_key!
+      login_user user
+
       visit spree.edit_admin_shipment_path(shipment)
     end
 

--- a/spec/models/spree/stock/splitter/drop_ship_spec.rb
+++ b/spec/models/spree/stock/splitter/drop_ship_spec.rb
@@ -32,21 +32,17 @@ module Spree
         }
         let(:variant_4) { create(:variant) }
 
-        let(:line_item_1) { build(:line_item, variant: variant_1) }
-        let(:line_item_2) { build(:line_item, variant: variant_2) }
-        let(:line_item_3) { build(:line_item, variant: variant_3) }
-        let(:line_item_4) { build(:line_item, variant: variant_4) }
+        let(:variants){
+          [variant_1, variant_2, variant_3, variant_4]
+        }
 
         let(:packer) { build(:stock_packer) }
 
         subject { DropShip.new(packer) }
 
         it 'splits packages for drop ship' do
-          package = Package.new(packer.stock_location, packer.order)
-          package.add line_item_1, 1, :on_hand
-          package.add line_item_2, 1, :on_hand
-          package.add line_item_3, 1, :on_hand
-          package.add line_item_4, 1, :on_hand
+          package = Package.new(packer.stock_location)
+          4.times { |i| package.add build(:inventory_unit, variant: variants[i]) }
 
           packages = subject.split([package])
           packages.count.should eq 3

--- a/spec/models/spree/supplier_ability_spec.rb
+++ b/spec/models/spree/supplier_ability_spec.rb
@@ -9,7 +9,7 @@ describe Spree::SupplierAbility do
   let(:token) { nil }
 
   context 'for Dash' do
-    let(:resource) { Spree::Admin::OverviewController }
+    let(:resource) { Spree::Admin::RootController }
 
     context 'requested by supplier' do
       it_should_behave_like 'access denied'


### PR DESCRIPTION
This pull request is for handling the case when a variant has more than one supplier...
Previously only the first supplier with lowest cost is chosen during packages splitting even if it has no available  stock items 
```
supplier = content.variant.supplier_variants.order('spree_supplier_variants.cost ASC').first.supplier
```
which will lead to `count on hand must be greater than 0` exception incase this first supplier has no stock for the variant in the package

These are the changes made to solve this:
--------------------------------------------------------

* Add `available?` method to `StockLocation`
* Add `stock_locations_with_available_stock_items` to `Supplier`
* Modify the `drop_ship` splitter to take advantage of the above methods

