### PR TITLE
Check if stock_item exists before adding variant to stock_location

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -24,7 +24,7 @@ Spree::Product.class_eval do
     variants_including_master.each do |variant|
       unless variant.suppliers.pluck(:id).include?(supplier.id)
         variant.suppliers << supplier
-        supplier.stock_locations.each { |location| location.propagate_variant(variant) }
+        supplier.stock_locations.each { |location| location.set_up_stock_item(variant) }
       end
     end
   end


### PR DESCRIPTION
The only different between `propagate_variant` and `set_up_stock_item` is that `set_up_stock_item ` checks if a stock_item exist for this variant at this location before creating a new one. This has proven to be useful in various occasions for me - when setting up test objects, or when we set up the suppliers/products slightly differently. Without the check, if some how the stock_item already exists, rails gives a validation error like: Variant already exists.

I've only tested it in 2-4, but doesn't seem to me this part of the code has changed much from 2-3 to 3-0, so probably safe to apply this to all of those branches.