### PR TITLE
Make Shipping State Ransackable.

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -8,6 +8,8 @@ Spree::Shipment.class_eval do
 
   delegate :supplier, to: :stock_location
 
+  self.whitelisted_ransackable_attributes = ['number', 'state']
+
   def display_final_price_with_items
     Spree::Money.new final_price_with_items
   end


### PR DESCRIPTION
Shipping state was not ransackable, and was leading to this error on a fresh install: https://github.com/spree-contrib/spree_drop_ship/issues/73

The "state" attributed just needed to be added to the whitelist.